### PR TITLE
Fix: Udpate demo link and add 'studio' to cd command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
     <a href="https://github.com/onlook-dev/studio"><strong>Explore the docs »</strong></a>
     <br />
     <br />
-    <a href="https://github.com/onlook-dev/studio">View Demo</a>
+    <a href="https://github.com/onlook-dev/studio?tab=readme-ov-file#about">View Demo</a>
     ·
     <a href="https://github.com/onlook-dev/studio/issues/new?labels=bug&template=bug-report---.md">Report Bug</a>
     ·
@@ -77,9 +77,9 @@ https://github.com/onlook-dev/studio/assets/31864905/ea429342-03bc-40b2-8a94-d39
    ```sh
    git clone https://github.com/onlook-dev/studio.git
    ```
-2. Navigate to app folder
+2. Navigate to app folder inside the project
    ```sh
-   cd app
+   cd studio/app
    ```
 3. Install NPM packages
    ```sh


### PR DESCRIPTION
### Description

Super minor changes, but just something I ran into.

- Fix "View Demo" link (might be eaiser to just link directly to video)
- User should be able to execute all the commands verbatim to run the project

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] New feature
- [x] Documentation update
- [ ] Bug fix
- [ ] Refactor
- [ ] Other
