### PR TITLE
use rimraf to remove .next folder

### DIFF
--- a/demos/next/package.json
+++ b/demos/next/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "scripts": {
-    "dev": "rm -rf .next && next dev",
+    "dev": "rimraf .next && next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
@@ -50,6 +50,7 @@
     "eslint-plugin-tailwindcss": "^3.13.0",
     "postcss": "^8.4.24",
     "prettier": "^2.8.8",
+    "rimraf": "6.0.1",
     "tailwindcss": "^3.3.2",
     "typescript": "^4.9.5"
   }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] New feature
- [ ] Documentation update
- [x] Bug fix
- [ ] Refactor
- [ ] Other


When running the Next.js example on Windows. `rm -rf .next` fails because it's not a Powershell/Bash command. I fixed this by adding `rimraf` to the dev dependecies of the Next.js demo project and used that to remove the `.next` folder

