### PR TITLE
Feature/zoom hotkeys for mouse

### DIFF
--- a/app/electron/main/index.ts
+++ b/app/electron/main/index.ts
@@ -68,8 +68,6 @@ function createWindow() {
 
 function initMainWindow() {
     const win = createWindow();
-    // Menu.setApplicationMenu(new Menu());
-    // win.menuBarVisible = true;
     win.maximize();
     loadWindowContent(win);
 

--- a/app/electron/main/index.ts
+++ b/app/electron/main/index.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, app, shell } from 'electron';
+import { BrowserWindow, Menu, app, shell } from 'electron';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
@@ -68,6 +68,8 @@ function createWindow() {
 
 function initMainWindow() {
     const win = createWindow();
+    Menu.setApplicationMenu(new Menu());
+    win.menuBarVisible = false;
     win.maximize();
     loadWindowContent(win);
 

--- a/app/electron/main/index.ts
+++ b/app/electron/main/index.ts
@@ -1,4 +1,4 @@
-import { BrowserWindow, Menu, app, shell } from 'electron';
+import { BrowserWindow, app, shell } from 'electron';
 import { createRequire } from 'node:module';
 import os from 'node:os';
 import path from 'node:path';
@@ -68,8 +68,8 @@ function createWindow() {
 
 function initMainWindow() {
     const win = createWindow();
-    Menu.setApplicationMenu(new Menu());
-    win.menuBarVisible = false;
+    // Menu.setApplicationMenu(new Menu());
+    // win.menuBarVisible = true;
     win.maximize();
     loadWindowContent(win);
 

--- a/app/electron/preload/browserview/index.ts
+++ b/app/electron/preload/browserview/index.ts
@@ -60,3 +60,4 @@ const api = {
 contextBridge.exposeInMainWorld('api', api);
 contextBridge.exposeInMainWorld('store', store);
 contextBridge.exposeInMainWorld('env', env);
+contextBridge.exposeInMainWorld('process', process);

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -13,3 +13,6 @@ export function assertNever(n: never): never {
 export function sendAnalytics(event: string, data?: Record<string, any>) {
     window.api.send(MainChannels.SEND_ANALYTICS, { event, data });
 }
+
+export const isMetaKey = (e: Pick<KeyboardEvent, 'ctrlKey' | 'metaKey'>) =>
+    process.platform === 'darwin' ? e.metaKey : e.ctrlKey;

--- a/app/src/routes/project/Canvas/PanOverlay.tsx
+++ b/app/src/routes/project/Canvas/PanOverlay.tsx
@@ -1,7 +1,7 @@
 import { EditorMode } from '@/lib/models';
 import clsx from 'clsx';
 import { observer } from 'mobx-react-lite';
-import { useState, useCallback, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useEditorEngine } from '..';
 
 interface PanOverlayProps {

--- a/app/src/routes/project/Canvas/PanOverlay.tsx
+++ b/app/src/routes/project/Canvas/PanOverlay.tsx
@@ -1,7 +1,7 @@
 import { EditorMode } from '@/lib/models';
 import clsx from 'clsx';
 import { observer } from 'mobx-react-lite';
-import { useState } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useEditorEngine } from '..';
 
 interface PanOverlayProps {
@@ -15,6 +15,28 @@ interface PanOverlayProps {
 const PanOverlay = observer(({ setPosition }: PanOverlayProps) => {
     const editorEngine = useEditorEngine();
     const [isPanning, setIsPanning] = useState(false);
+
+    const spacebarDown = useCallback((e: KeyboardEvent) => {
+        if (e.key === ' ') {
+            editorEngine.mode = EditorMode.PAN;
+        }
+    }, []);
+
+    const spaceBarUp = useCallback((e: KeyboardEvent) => {
+        if (e.key === ' ') {
+            editorEngine.mode = EditorMode.DESIGN;
+        }
+    }, []);
+
+    useEffect(() => {
+        window.addEventListener('keydown', spacebarDown);
+        window.addEventListener('keyup', spaceBarUp);
+
+        return () => {
+            window.removeEventListener('keydown', spacebarDown);
+            window.removeEventListener('keyup', spaceBarUp);
+        };
+    }, []);
 
     const startPan = (event: React.MouseEvent<HTMLDivElement>) => {
         event.preventDefault();

--- a/app/src/routes/project/Canvas/PanOverlay.tsx
+++ b/app/src/routes/project/Canvas/PanOverlay.tsx
@@ -1,7 +1,6 @@
 import { EditorMode } from '@/lib/models';
 import clsx from 'clsx';
 import { observer } from 'mobx-react-lite';
-import { useCallback, useEffect, useState } from 'react';
 import { useEditorEngine } from '..';
 
 interface PanOverlayProps {
@@ -11,50 +10,11 @@ interface PanOverlayProps {
             y: number;
         }>
     >;
+    isPanning: boolean;
+    setIsPanning: React.Dispatch<React.SetStateAction<boolean>>;
 }
-const PanOverlay = observer(({ setPosition }: PanOverlayProps) => {
+const PanOverlay = observer(({ setPosition, isPanning, setIsPanning }: PanOverlayProps) => {
     const editorEngine = useEditorEngine();
-    const [isPanning, setIsPanning] = useState(false);
-
-    const spaceBarDown = (e: KeyboardEvent) => {
-        if (e.key === ' ') {
-            editorEngine.mode = EditorMode.PAN;
-        }
-    };
-
-    const spaceBarUp = useCallback((e: KeyboardEvent) => {
-        if (e.key === ' ') {
-            editorEngine.mode = EditorMode.DESIGN;
-        }
-    }, []);
-
-    const middleMouseButtonDown = (e: MouseEvent) => {
-        if (e.button === 1) {
-            editorEngine.mode = EditorMode.PAN;
-            setIsPanning(true);
-        }
-    };
-
-    const middleMouseButtonUp = (e: MouseEvent) => {
-        if (e.button === 1) {
-            editorEngine.mode = EditorMode.DESIGN;
-            setIsPanning(false);
-        }
-    };
-
-    useEffect(() => {
-        window.addEventListener('keydown', spaceBarDown);
-        window.addEventListener('keyup', spaceBarUp);
-        window.addEventListener('mousedown', middleMouseButtonDown);
-        window.addEventListener('mouseup', middleMouseButtonUp);
-
-        return () => {
-            window.removeEventListener('keydown', spaceBarDown);
-            window.removeEventListener('keyup', spaceBarUp);
-            window.removeEventListener('mousedown', middleMouseButtonDown);
-            window.removeEventListener('mouseup', middleMouseButtonUp);
-        };
-    }, []);
 
     const startPan = (event: React.MouseEvent<HTMLDivElement>) => {
         event.preventDefault();

--- a/app/src/routes/project/Canvas/PanOverlay.tsx
+++ b/app/src/routes/project/Canvas/PanOverlay.tsx
@@ -16,11 +16,11 @@ const PanOverlay = observer(({ setPosition }: PanOverlayProps) => {
     const editorEngine = useEditorEngine();
     const [isPanning, setIsPanning] = useState(false);
 
-    const spacebarDown = useCallback((e: KeyboardEvent) => {
+    const spaceBarDown = (e: KeyboardEvent) => {
         if (e.key === ' ') {
             editorEngine.mode = EditorMode.PAN;
         }
-    }, []);
+    };
 
     const spaceBarUp = useCallback((e: KeyboardEvent) => {
         if (e.key === ' ') {
@@ -28,13 +28,31 @@ const PanOverlay = observer(({ setPosition }: PanOverlayProps) => {
         }
     }, []);
 
+    const middleMouseButtonDown = (e: MouseEvent) => {
+        if (e.button === 1) {
+            editorEngine.mode = EditorMode.PAN;
+            setIsPanning(true);
+        }
+    };
+
+    const middleMouseButtonUp = (e: MouseEvent) => {
+        if (e.button === 1) {
+            editorEngine.mode = EditorMode.DESIGN;
+            setIsPanning(false);
+        }
+    };
+
     useEffect(() => {
-        window.addEventListener('keydown', spacebarDown);
+        window.addEventListener('keydown', spaceBarDown);
         window.addEventListener('keyup', spaceBarUp);
+        window.addEventListener('mousedown', middleMouseButtonDown);
+        window.addEventListener('mouseup', middleMouseButtonUp);
 
         return () => {
-            window.removeEventListener('keydown', spacebarDown);
+            window.removeEventListener('keydown', spaceBarDown);
             window.removeEventListener('keyup', spaceBarUp);
+            window.removeEventListener('mousedown', middleMouseButtonDown);
+            window.removeEventListener('mouseup', middleMouseButtonUp);
         };
     }, []);
 

--- a/app/src/routes/project/Canvas/index.tsx
+++ b/app/src/routes/project/Canvas/index.tsx
@@ -67,6 +67,34 @@ const Canvas = ({ children }: { children: ReactNode }) => {
         }
     }, [handleWheel]);
 
+    const handleZoomShortcut = (event: KeyboardEvent) => {
+        if (!isMetaKey(event)) {
+            return;
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        switch (event.key) {
+            case '0':
+                setScale(1);
+                break;
+            case '=':
+                setScale(scale * 1.2);
+                break;
+            case '-':
+                setScale(scale * 0.8);
+                break;
+        }
+    };
+
+    useEffect(() => {
+        window.addEventListener('keydown', handleZoomShortcut);
+        return () => {
+            window.removeEventListener('keydown', handleZoomShortcut);
+        };
+    }, [handleZoomShortcut]);
+
     useEffect(() => {
         editorEngine.scale = scale;
     }, [position, scale]);

--- a/app/src/routes/project/Canvas/index.tsx
+++ b/app/src/routes/project/Canvas/index.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import { useEditorEngine } from '..';
 import PanOverlay from './PanOverlay';
+import { isMetaKey } from '@/lib/utils';
 
 const Canvas = ({ children }: { children: ReactNode }) => {
     const [position, setPosition] = useState({ x: 300, y: 50 });
@@ -12,9 +13,7 @@ const Canvas = ({ children }: { children: ReactNode }) => {
     const panSensitivity = 0.52;
 
     const handleWheel = (event: WheelEvent) => {
-        const zoomKey = process.platform === 'darwin' ? event.metaKey : event.ctrlKey;
-
-        if (zoomKey) {
+        if (isMetaKey(event)) {
             handleZoom(event);
         } else {
             handlePan(event);

--- a/app/src/routes/project/Canvas/index.tsx
+++ b/app/src/routes/project/Canvas/index.tsx
@@ -1,7 +1,7 @@
+import { isMetaKey } from '@/lib/utils';
 import { ReactNode, useEffect, useRef, useState } from 'react';
 import { useEditorEngine } from '..';
 import PanOverlay from './PanOverlay';
-import { isMetaKey } from '@/lib/utils';
 
 const Canvas = ({ children }: { children: ReactNode }) => {
     const [position, setPosition] = useState({ x: 300, y: 50 });
@@ -13,7 +13,7 @@ const Canvas = ({ children }: { children: ReactNode }) => {
     const panSensitivity = 0.52;
 
     const handleWheel = (event: WheelEvent) => {
-        if (isMetaKey(event)) {
+        if (event.ctrlKey) {
             handleZoom(event);
         } else {
             handlePan(event);
@@ -71,10 +71,7 @@ const Canvas = ({ children }: { children: ReactNode }) => {
         if (!isMetaKey(event)) {
             return;
         }
-
-        event.preventDefault();
-        event.stopPropagation();
-
+        let shouldPreventDefault = true;
         switch (event.key) {
             case '0':
                 setScale(1);
@@ -85,6 +82,13 @@ const Canvas = ({ children }: { children: ReactNode }) => {
             case '-':
                 setScale(scale * 0.8);
                 break;
+            default:
+                shouldPreventDefault = false;
+        }
+
+        if (shouldPreventDefault) {
+            event.preventDefault();
+            event.stopPropagation();
         }
     };
 

--- a/app/src/routes/project/Canvas/index.tsx
+++ b/app/src/routes/project/Canvas/index.tsx
@@ -12,7 +12,9 @@ const Canvas = ({ children }: { children: ReactNode }) => {
     const panSensitivity = 0.52;
 
     const handleWheel = (event: WheelEvent) => {
-        if (event.ctrlKey) {
+        const zoomKey = process.platform === 'darwin' ? event.metaKey : event.ctrlKey;
+
+        if (zoomKey) {
             handleZoom(event);
         } else {
             handlePan(event);

--- a/app/src/routes/project/TopBar/ModeToggle.tsx
+++ b/app/src/routes/project/TopBar/ModeToggle.tsx
@@ -1,12 +1,20 @@
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { EditorMode } from '@/lib/models';
 import { observer } from 'mobx-react-lite';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useEditorEngine } from '..';
 
 const ModeToggle = observer(() => {
     const editorEngine = useEditorEngine();
-    const [mode, setMode] = useState<EditorMode>(editorEngine.mode);
+    const [mode, setMode] = useState<EditorMode>(makeDesignMode(editorEngine.mode));
+
+    useEffect(() => {
+        setMode(makeDesignMode(editorEngine.mode));
+    }, [editorEngine.mode]);
+
+    function makeDesignMode(mode: EditorMode) {
+        return mode === EditorMode.INTERACT ? EditorMode.INTERACT : EditorMode.DESIGN;
+    }
 
     return (
         <ToggleGroup


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
This PR adds a number of quality of life features related to zooming and panning as per this issue: https://github.com/onlook-dev/studio/issues/121

Breakdown:
- while the spacebar is pressed, the pan mode is active, releasing the spacebar puts the editor into design mode
- while the middle mouse button is pressed, the pan mode is active (same thing as with the space bar)
- holding the command key on macOS and control on any other platform zooms the canvas on scroll
- cmd/ctrl +/- zooms the canvas in/out. For this feature to work, the main menu bar had to be disabled (since the default shortcuts overrode the custom ones). This commit (https://github.com/onlook-dev/studio/commit/ecc09d93d84eadfd0aae0058d8fa5c691354fb2e) could be split out into it's own PR for completeness' sake

Tech notes:
- re: the zoom shortcut (cmd/ctrl +/-): ideally all shortcuts would be handled in a uniform way, so I'm a bit on the fence about adding it now because it would create some tech debt that'll have to be cleaned up when the said uniform shortcut system is added (even though the linked issue asks for the zoom shortcuts). This PR includes these shortcuts anyway, but they can be easily removed by reverting this commit https://github.com/onlook-dev/studio/commit/883f3ba543c993739bdc6eec481bd55aeecd9386 

### What is the purpose of this pull request? 

<!-- (put an "X" next to an item) -->

- [x] New feature
- [ ] Documentation update
- [ ] Bug fix
- [ ] Refactor
- [ ] Release
- [ ] Other
